### PR TITLE
remove ethers/wordlists

### DIFF
--- a/packages/web3-ppos/index.js
+++ b/packages/web3-ppos/index.js
@@ -5,7 +5,6 @@ var Common = require('ethereumjs-common');
 var EthereumTx = require('ethereumjs-tx');
 var axios = require('axios');
 var utils = require('web3-utils');
-const { es } = require('ethers/wordlists');
 const paramsOrder = {
     '1000': ['typ', 'benefitAddress', 'nodeId', 'externalId', 'nodeName', 'website', 'details', 'amount', 'rewardPer', 'programVersion', 'programVersionSign', 'blsPubKey', 'blsProof'],
     '1001': ['benefitAddress', 'nodeId', 'rewardPer', 'externalId', 'nodeName', 'website', 'details'],


### PR DESCRIPTION
1. install client-sdk-js
```
npm i PlatONnetwork/client-sdk-js#master
```

2. require web3
```
const Web3 = require('web3');
```

output error:
```
internal/modules/cjs/loader.js:670
    throw err;
    ^

Error: Cannot find module 'ethers/wordlists'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:668:15)
    at Function.Module._load (internal/modules/cjs/loader.js:591:27)
    at Module.require (internal/modules/cjs/loader.js:723:19)
    at require (internal/modules/cjs/helpers.js:14:16)
    at Object.<anonymous> (/home/yy/contracts/platon-hackathon/client/node_modules/web3/packages/web3-ppos/index.js:8:16)
    at Module._compile (internal/modules/cjs/loader.js:816:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:827:10)
    at Module.load (internal/modules/cjs/loader.js:685:32)
    at Function.Module._load (internal/modules/cjs/loader.js:620:12)
    at Module.require (internal/modules/cjs/loader.js:723:19)
```

web3 module ethers/wordlists is never used, and not installed in package.json. 

It's works after remove require ethers/wordlists. 