### PR TITLE
Fix: js sdk wasm contract encodeEventSignature mismatch Platon-CDT event_sign

### DIFF
--- a/packages/web3-eth-abi/src/index.js
+++ b/packages/web3-eth-abi/src/index.js
@@ -115,7 +115,11 @@ ABICoder.prototype.encodeEventSignature = function (functionName) {
     }
     // keccak256(rlp(EVENT名称字符串)) 得到的[32]byte
     if (this.vmType) {
-        functionName = RLP.encode(functionName.split("(")[0]);
+        functionName = utils.toHex(functionName.split("(")[0]);
+        // functionName length contains '0x'
+        if (functionName.length - 2 <= 64) {
+            return utils.leftPad(functionName, 64);
+        }
     }
     return utils.sha3(functionName);
 };


### PR DESCRIPTION
Code:
```js
contract.methods.event_test(id, size).send({
    from: ownerAddress, gas: 999999
}).on('receipt', function(receipt) {
  console.log(receipt);
}).on('error', console.error);
```
return value:
```js
{
  ...
  events: {
    '0': {
      address: 'lat1r7pm24l8sav5xqg7pwrfe89n77j66w4xdp5m9q',
      blockNumber: 116876,
      transactionHash: '0x33b48eb7aabaa281fac3dfe4d2c154b96e79ec73485f7200a67f6aba5a49cdee',
      transactionIndex: 0,
      blockHash: '0xbaa5e9bd473b92e21ddad74562b170fcd7cbb257b47486c1ee97c63b838e92ad',
      logIndex: 0,
      removed: false,
      id: 'log_eb9d4df6',
      returnValues: Result {},
      event: undefined,
      signature: null,
      raw: [Object]
    }
  }
}
```
events 不显示 event 名称、签名以及 returnValues 的具体值。

原因：Platon-CDT 和 client-sdk-js 的 event 签名不一致导致。
Platon-CDT:
只有在 event 的长度超过 32 时才会进行 sha3 处理
```c++
// event.hpp
template <typename T>
bytes event_bytes_data_convert(const T &data) {
  bytes result(data.cbegin(), data.cend());
  if (result.size() <= 32) {
    return result;
  }

  bytes hash;
  hash.resize(32);
  ::platon_sha3(result.data(), result.size(), hash.data(), hash.size());
  return hash;
}
```

client-sdk-js:
event 始终会进行 sha3 处理
```js
// web3-eth-abi
ABICoder.prototype.encodeEventSignature = function (functionName) {
    if (_.isObject(functionName)) {
        functionName = utils._jsonInterfaceMethodToString(functionName);
    }
    // keccak256(rlp(EVENT名称字符串)) 得到的[32]byte
    if (this.vmType) {
        functionName = RLP.encode(functionName.split("(")[0]);
    }
    return utils.sha3(functionName);
};
```